### PR TITLE
Added a custom action for loading sample data

### DIFF
--- a/charm/charmcraft.yaml
+++ b/charm/charmcraft.yaml
@@ -30,6 +30,10 @@ requires:
     interface: postgresql_client
     optional: false
 
+actions:
+  load-sample-data:
+    description: Load the sample data that comes with the application.
+
 links:
   source:
   - https://github.com/canonical/dashboard/tree/charmed-version

--- a/charm/src/charm.py
+++ b/charm/src/charm.py
@@ -8,7 +8,6 @@ import logging
 import typing
 
 import ops
-
 import paas_charm.django
 
 logger = logging.getLogger(__name__)
@@ -24,6 +23,21 @@ class DashboardCharm(paas_charm.django.Charm):
             args: passthrough to CharmBase.
         """
         super().__init__(*args)
+        self.framework.observe(self.on.load_sample_data_action, self._on_load_sample_data)
+
+    def _on_load_sample_data(self, event: ops.ActionEvent):
+        """Load the application's sample data, using a command in the Django container."""
+        command = ["python3", "manage.py", "loaddata", "initial_data.yaml"]
+        working_dir = str(self._workload_config.app_dir)
+        try:
+            process = self._container.exec(
+                command,
+                working_dir=working_dir,
+                service_context="django",
+            )
+            process.wait()  # Raise an error if there was an error running the process.
+        except (ops.pebble.APIError, ops.pebble.ChangeError, ops.pebble.ExecError):
+            event.fail("unable to load sample data")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds a custom action called `load-sample-data` to the charm code. After deploying the charm and integrating it with postgresql-k8s, the user can run the following command to load sample data into the dashboard:

```
juju run dashboard/0 load-sample-data
```